### PR TITLE
Update packer to v1.7.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/packer:1.7.4
+FROM hashicorp/packer:1.7.2
 
 LABEL "com.github.actions.name" = "Packer build"
 LABEL "com.github.actions.description" = "Run packer build on a template file"


### PR DESCRIPTION
Reverting to packer version 1.7.2 due to [a bug](https://github.com/hashicorp/packer/issues/11169) that I consider to be pretty important.